### PR TITLE
don't 'use Moo::Role' in main plugin for compat with next Dancer2 release

### DIFF
--- a/lib/Dancer2/Plugin/Shutdown.pm
+++ b/lib/Dancer2/Plugin/Shutdown.pm
@@ -5,7 +5,6 @@ package Dancer2::Plugin::Shutdown;
 # ABSTRACT: Graceful shutdown your Dancer2 application
 
 use Dancer2::Plugin;
-use Moo::Role 2;
 
 with 'Dancer2::Plugin::Role::Shutdown';
 


### PR DESCRIPTION
In the next Dancer2 release the plugin system has been completely
overhauled and plugins are now Moo classes so trying to use Moo::Role in
a plugin is a fail.
